### PR TITLE
make edit_snippet always edit anonymously

### DIFF
--- a/src/modules/snippets.js
+++ b/src/modules/snippets.js
@@ -25,7 +25,7 @@ module.exports = bot => {
     const snippet = await snippets.get(trigger);
     if (! snippet) return;
 
-    await thread.replyToUser(msg.member, snippet.body, [], !! snippet.is_anonymous);
+    await thread.replyToUser(msg.member, snippet.body, [], true);
     msg.delete();
   });
 

--- a/src/modules/snippets.js
+++ b/src/modules/snippets.js
@@ -97,12 +97,7 @@ module.exports = bot => {
       return;
     }
 
-    let isAnonymous = snippet.isAnonymous;
-
-    if (args[1] === 'anon') {
-      text = args.slice(2).join(' ').trim();
-      isAnonymous = true;
-    }
+    let isAnonymous = true;
 
     await snippets.del(trigger);
     await snippets.add(trigger, text, isAnonymous);


### PR DESCRIPTION
since all snippets are anonymous, removed the function to use "!edit_snippet name (anon) content" and set isAnonymous to true by default